### PR TITLE
Specified postedBefore is exclusive and postedAfter is inclusive

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -518,7 +518,7 @@
                 },
                 {
                   "name": "postedBefore",
-                  "description": "Select Posts which were posted before the given date and time.",
+                  "description": "Select Posts which were posted before the given date and time. Exclusive boundary.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "DateTime",
@@ -528,7 +528,7 @@
                 },
                 {
                   "name": "postedAfter",
-                  "description": "Select Posts which were posted after the given date and time.",
+                  "description": "Select Posts which were posted after the given date and time. Inclusive boundary.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "DateTime",


### PR DESCRIPTION
I have tried the following query:

```
{
  posts(first: 1, postedAfter: "2021-10-10T21:48:48Z", postedBefore: "2021-10-10T21:48:49Z", order: NEWEST) {
    totalCount
    edges {
      node {
        id
        name
        createdAt
        url
      }
    }
  }
}
```

This gives a post that is posted at `"2021-10-10T21:48:48Z"`. Changing `postedBefore` to the same timestamp excludes the post from returned data. Meaning upper bound is exclusive.